### PR TITLE
remove use of undefined behavior per C++ standard

### DIFF
--- a/source/BatchedGeometry.cpp
+++ b/source/BatchedGeometry.cpp
@@ -178,7 +178,13 @@ uint32 CountUsedVertices(IndexData *id, std::map<uint32, uint32> &ibmap)
 
             for (i = 0; i < id->indexCount; i++) {
                uint16 index = data[i];
-               if (ibmap.find(index) == ibmap.end()) ibmap[index] = (uint32)(ibmap.size());
+               if (ibmap.find(index) == ibmap.end()) 
+	       {
+		    // use separate lines to avoid undefined compiler behavior.
+		    //   see: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf?fbclid=IwAR2Wp4bQWvl0O9t7kBIXeiRsOxwxU8bttpes-gK71x_2j0ABtzGD5mcoF_c
+		    uint32 size = (uint32)(ibmap.size()); 
+		    ibmap[index] = size;
+	       }
             }
             count = (uint32)ibmap.size();
             id->indexBuffer->unlock();
@@ -192,7 +198,13 @@ uint32 CountUsedVertices(IndexData *id, std::map<uint32, uint32> &ibmap)
 
             for (i = 0; i < id->indexCount; i++) {
                uint32 index = data[i];
-               if (ibmap.find(index) == ibmap.end()) ibmap[index] = (uint32)(ibmap.size());
+               if (ibmap.find(index) == ibmap.end()) 
+	       {
+		    // use separate lines to avoid undefined compiler behavior.
+		    //   see: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0145r3.pdf?fbclid=IwAR2Wp4bQWvl0O9t7kBIXeiRsOxwxU8bttpes-gK71x_2j0ABtzGD5mcoF_c
+		    uint32 size = (uint32)(ibmap.size()); 
+		    ibmap[index] = size;
+	       }
             }
             count = (uint32)ibmap.size();
             id->indexBuffer->unlock();


### PR DESCRIPTION
> if (ibmap.find(index) == ibmap.end()) ibmap[index] = (uint32)(ibmap.size());

on a c++ 14 compiler (microsoft, gcc) the ibmap.size() above evaluates to a 1 instead of the expected 0 that was returned when this code was originally written.  the fix is to move the .size() call to a separate line to explicitly force the order of operations.

these values are used as offset multipliers in a memcpy() for meshes with shared vertices.  if the value is off by 1 then the copy will overwrite the buffer corrupting the heap and causing crashes.  see BatchedGeometry::extractVertexDataFromShared() via memcpy().

note this only happens in optimized (release) builds and not debug.  this does not occur prior to c++ 14 and is fixed in c++ 17. 

fixes https://github.com/OGRECave/ogre-pagedgeometry/issues/8
